### PR TITLE
fix: 「すべて選択」にフィルタがうまく適用されていなかった問題を修正

### DIFF
--- a/app/components/BulkSelectButton.tsx
+++ b/app/components/BulkSelectButton.tsx
@@ -1,47 +1,22 @@
 import type { Event, SelectedSchedule } from "./types";
 
 type BulkSelectButtonProps = {
-	events: Event[];
+	filteredEvents: Event[];
 	selectedSchedules: SelectedSchedule[];
-	viewMode: "floor" | "today";
-	selectedFloor: string;
-	showAndroidOnly: boolean;
 	onBulkToggle: (schedules: SelectedSchedule[]) => void;
 };
 
 export function BulkSelectButton({
-	events,
+	filteredEvents,
 	selectedSchedules,
-	viewMode,
-	selectedFloor,
-	showAndroidOnly,
 	onBulkToggle,
 }: BulkSelectButtonProps) {
-	const getFilteredEvents = () => {
-		const today = new Date();
-		return events
-			.filter((event) => {
-				if (viewMode === "today") {
-					return event.schedules.some(
-						(schedule) =>
-							schedule.date.year === today.getFullYear() &&
-							schedule.date.month === today.getMonth() + 1 &&
-							schedule.date.day === today.getDate(),
-					);
-				}
-				return event.floor === selectedFloor;
-			})
-			.filter(
-				(event) => !showAndroidOnly || event.platform.includes("Android"),
-			);
-	};
-
 	const getAllSchedulesCount = () => {
-		return getFilteredEvents().flatMap((e) => e.schedules).length;
+		return filteredEvents.flatMap((e) => e.schedules).length;
 	};
 
 	const handleBulkToggle = () => {
-		const allSchedules = getFilteredEvents().flatMap((event) =>
+		const allSchedules = filteredEvents.flatMap((event) =>
 			event.schedules.map((schedule) => ({
 				uid: event.uid,
 				schedule: {

--- a/app/hooks/useFilteredEvents.ts
+++ b/app/hooks/useFilteredEvents.ts
@@ -1,0 +1,50 @@
+import type { Event } from "../components/types";
+
+type FilterOptions = {
+	events: Event[];
+	viewMode: "floor" | "today";
+	selectedFloor: string;
+	showAndroidOnly: boolean;
+};
+
+export const useFilteredEvents = () => {
+	const getFilteredEvents = ({
+		events,
+		viewMode,
+		selectedFloor,
+		showAndroidOnly,
+	}: FilterOptions) => {
+		const today = new Date();
+		return events
+			.filter((event) => {
+				if (viewMode === "today") {
+					return event.schedules.some(
+						(schedule) =>
+							schedule.date.year === today.getFullYear() &&
+							schedule.date.month === today.getMonth() + 1 &&
+							schedule.date.day === today.getDate(),
+					);
+				}
+				return event.floor === selectedFloor;
+			})
+			.filter((event) => !showAndroidOnly || event.platform.includes("Android"))
+			.map((event) => {
+				if (viewMode === "today") {
+					return {
+						...event,
+						schedules: event.schedules.filter((schedule) => {
+							const today = new Date();
+							return (
+								schedule.date.year === today.getFullYear() &&
+								schedule.date.month === today.getMonth() + 1 &&
+								schedule.date.day === today.getDate()
+							);
+						}),
+					};
+				}
+				return event;
+			});
+	};
+
+	return { getFilteredEvents };
+};


### PR DESCRIPTION
Add useFilteredEvents hook and refactor event filtering logic

- Create useFilteredEvents hook to centralize event filtering
- Update BulkSelectButton to use filtered events directly
- Simplify event rendering in _index route by using filtered events
- Add e2e test for Android-only event selection
