### PR TITLE
feat: スクレイピングスクリプトの安定性と待機時間を改善

### DIFF
--- a/.github/workflows/check-timetable-updates.yml
+++ b/.github/workflows/check-timetable-updates.yml
@@ -47,6 +47,7 @@ jobs:
           git add .
           git status --porcelain
           echo "changes=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT
+          echo "diff_stats=$(git diff --cached --stat | tail -n 1)" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request if changes detected
         if: steps.git-check.outputs.changes > 0
@@ -59,6 +60,7 @@ jobs:
             
             ## 変更内容
             - scripts/scraped-events.json の更新
+            - 変更統計: ${{ steps.git-check.outputs.diff_stats }}
             
             変更内容を確認の上、マージをお願いします。
           branch: update/timetable

--- a/scripts/scrape.mts
+++ b/scripts/scrape.mts
@@ -70,8 +70,13 @@ function convertTimeToComparable(timeStr: string): string {
 	> => {
 		await page.goto(`https://v-fes.sanrio.co.jp/timetable/${date}`, {
 			waitUntil: "networkidle",
-			timeout: 120000,
+			timeout: 180000,
 		});
+
+		// "a.link.sd.appear", "button.link.sd.appear" どちらかが見つかるまで待機
+		await page.waitForSelector("a.link.sd.appear, button.link.sd.appear");
+		// 追加で5秒待機
+		await new Promise((resolve) => setTimeout(resolve, 5000));
 
 		const linkEvents = await page.$$eval(
 			"a.link.sd.appear",


### PR DESCRIPTION
- タイムアウト時間を120秒から180秒に延長
- セレクタの待機処理を追加
- ページ読み込み後に追加の5秒待機を実装

また、GitHub Actionsワークフローに変更統計の出力を追加
